### PR TITLE
More pathlib usage

### DIFF
--- a/uvtrick/__init__.py
+++ b/uvtrick/__init__.py
@@ -34,6 +34,9 @@ def uvtrick_(path, func, *args, **kwargs):
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_dir = Path(temp_dir)
+        script = temp_dir / "pytemp.py"
+        output = temp_dir / "tmp.pickle"
+
         code = Path(path).read_text()
         idx = code.find("if __name__")
         code = code[:idx] + "\n\n"
@@ -48,14 +51,11 @@ def uvtrick_(path, func, *args, **kwargs):
     with open('tmp.pickle', 'wb') as f:
         pickle.dump({func}({string_args} {string_kwargs}), f)\n"""
 
-        Path(temp_dir / "pytemp.py").write_text(code)
+        script.write_text(code)
         # print(code)
         subprocess.run(f"uv run --quiet {str(temp_dir / 'pytemp.py')}", shell=True, cwd=temp_dir)
 
-        temp_pickle_path = os.path.join(temp_dir, "tmp.pickle")
-        with open(temp_pickle_path, 'rb') as file:
-            loaded_data = pickle.load(file)
-    return loaded_data
+        return pickle.loads(output.read_bytes())
 
 
 def load(path, func):

--- a/uvtrick/__init__.py
+++ b/uvtrick/__init__.py
@@ -19,12 +19,11 @@ def maincall(func, inputs_path, outputs_path):
     return f"""
 if __name__ == "__main__":
     import pickle
+    from pathlib import Path
 
-    with open('{inputs_path}', 'rb') as file:
-        args, kwargs = pickle.load(file)
-
-    with open('{outputs_path}', 'wb') as f:
-        pickle.dump({func.__name__}(*args, **kwargs), f)
+    args, kwargs = pickle.loads(Path('{inputs_path!s}').read_bytes())
+    result = {func.__name__}(*args, **kwargs)
+    Path('{outputs_path!s}').write_bytes(pickle.dumps(result))
 """
 
 def uvtrick_(path, func, *args, **kwargs):


### PR DESCRIPTION
This PR makes consistent use of pathlib Path types (broken out of previous PR #9 as requested)

- Declaring multiple paths in one part of code blocks (rather than 'on the fly' at point of use of each one) makes it clearer to read
- Writing `path.read_text()` / `write_bytes()` etc is more concise and thus more readable at a glance than `with open(...) as f: do_something(..., f)`, typically pickle operations which can use the `loads`/`dumps` version rather than `load`/`dump`