### PR TITLE
Add support for defining the environment variables in `Env`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 description = "A fun party trick to run Python code from another venv into this one."
 license = {text = "MIT"}
 name = "uvtrick"
-version = "0.4.2"
+version = "0.4.3"
 readme = "README.md"
 requires-python = ">=3.8"
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,5 +1,6 @@
 """When I hacks this bad, I write tests."""
 
+import os
 import pytest
 
 from uvtrick import Env, load
@@ -56,3 +57,21 @@ def test_env_works2():
             "dictionary": {"a": 1, "b": 2},
             "string": "hello",
         }
+
+def test_env_environment_variables():
+    def handles_all_types(arr, dictionary, string):
+        import os
+        assert os.environ.get("TEST_ENV_VAR") == "hello"
+        return os.environ.get("TEST_ENV_VAR")
+
+    env = os.environ.copy()
+    env["TEST_ENV_VAR"] = "hello"
+    out = Env(env=env).run(
+        handles_all_types,
+        arr=[1, 2, 3],
+        dictionary={"a": 1, "b": 2},
+        string="hello",
+    )
+    assert out == "hello"
+
+    # f"rich==13", 

--- a/uv.lock
+++ b/uv.lock
@@ -108,8 +108,8 @@ wheels = [
 
 [[package]]
 name = "uvtrick"
-version = "0.3.0"
-source = { virtual = "." }
+version = "0.4.2"
+source = { editable = "." }
 dependencies = [
     { name = "cloudpickle" },
     { name = "uv" },
@@ -122,7 +122,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cloudpickle", specifier = ">=3.1.0" },
+    { name = "cloudpickle", specifier = ">=2.0.0" },
     { name = "uv" },
 ]
 

--- a/uvtrick/__init__.py
+++ b/uvtrick/__init__.py
@@ -94,7 +94,7 @@ class Env:
         self.temp_dir: Path = None
         self.env = env
 
-        if env and "path" not in env:
+        if env and "PATH" not in env:
             warnings.warn("The PATH environment variable is not set in `env`, this may cause issues when running the script. Try using env=os.environ.copy() to copy the current environment first.")
 
     @property


### PR DESCRIPTION
I am using uvtrick to test a function that needs authentication, which is defined in environment variables (pulling artifacts from mlflow). This adds support for those kind of use cases.